### PR TITLE
Test : MemberServiceImpl에 대한 단위 테스트 메서드 구현 및 버그 픽스

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -11,6 +11,12 @@ java {
 	sourceCompatibility = '17'
 }
 
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
 repositories {
 	mavenCentral()
 }
@@ -22,11 +28,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	implementation 'org.projectlombok:lombok'
+	compileOnly 'org.projectlombok:lombok'
 
 	implementation 'commons-validator:commons-validator:1.7'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
+
+	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/auth/src/main/java/frogslayer/auth/member/entity/Member.java
+++ b/auth/src/main/java/frogslayer/auth/member/entity/Member.java
@@ -1,8 +1,6 @@
 package frogslayer.auth.member.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,7 +12,10 @@ import lombok.NoArgsConstructor;
 @Builder
 @Data
 public class Member {
+
     @Id
+    @Column
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
     @Column(nullable = false)

--- a/auth/src/main/java/frogslayer/auth/member/exception/ExceptionController.java
+++ b/auth/src/main/java/frogslayer/auth/member/exception/ExceptionController.java
@@ -25,7 +25,7 @@ public class ExceptionController {
         return getResponseEntity(ExceptionCode.INVALID_PASSWORD_FORMAT_EXCEPTION);
     }
 
-    @ExceptionHandler(InvalidEmailFormatException.class)
+    @ExceptionHandler(NoSuchUserException.class)
     public ResponseEntity<String> handleNoSuchUserException(NoSuchUserException err){
         return getResponseEntity(ExceptionCode.NO_SUCH_USER_EXCEPTION);
     }

--- a/auth/src/main/java/frogslayer/auth/member/service/MemberService.java
+++ b/auth/src/main/java/frogslayer/auth/member/service/MemberService.java
@@ -10,5 +10,9 @@ public interface MemberService {
 
     Member findUserByEmail(String email) throws NoSuchUserException;
     void signUp(Member signUpInfo) throws InvalidEmailFormatException, InvalidPasswordFormatException, DuplicateUserException;
+
+    void verifyPasswordFormat(String password) throws InvalidPasswordFormatException;
+    void verifyEmailFormat(String email) throws InvalidEmailFormatException;
+    void checkEmailDuplication(String email) throws DuplicateUserException;
 }
 

--- a/auth/src/main/java/frogslayer/auth/member/service/MemberServiceImpl.java
+++ b/auth/src/main/java/frogslayer/auth/member/service/MemberServiceImpl.java
@@ -37,17 +37,17 @@ public class MemberServiceImpl implements MemberService {
         memberRepository.save(member);
     }
 
-    private void verifyPasswordFormat(String password) throws InvalidPasswordFormatException {
+    public void verifyPasswordFormat(String password) throws InvalidPasswordFormatException {
         String regex =  "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$";
         if (!password.matches(regex)) throw new InvalidPasswordFormatException();
     }
 
-    private void verifyEmailFormat(String email) throws InvalidEmailFormatException {
+    public void verifyEmailFormat(String email) throws InvalidEmailFormatException {
         if (email.isBlank()) throw new InvalidEmailFormatException();
         if (!EmailValidator.getInstance().isValid(email)) throw new InvalidEmailFormatException();
     }
 
-    private void checkEmailDuplication(String email) throws DuplicateUserException {
+    public void checkEmailDuplication(String email) throws DuplicateUserException {
         if (memberRepository.existsByEmail(email)) throw new DuplicateUserException();
     }
 }

--- a/auth/src/main/java/frogslayer/auth/member/service/MemberServiceImpl.java
+++ b/auth/src/main/java/frogslayer/auth/member/service/MemberServiceImpl.java
@@ -24,9 +24,10 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public void signUp(Member signUpInfo) throws InvalidEmailFormatException, InvalidPasswordFormatException, DuplicateUserException{
         String email = signUpInfo.getEmail();
+        String password = signUpInfo.getPassword();
         verifyEmailFormat(email);
         checkEmailDuplication(email);
-        verifyPasswordFormat(email);
+        verifyPasswordFormat(password);
 
         Member member = Member.builder()
                 .email(signUpInfo.getEmail())

--- a/auth/src/main/java/frogslayer/auth/member/service/MemberServiceImpl.java
+++ b/auth/src/main/java/frogslayer/auth/member/service/MemberServiceImpl.java
@@ -37,8 +37,9 @@ public class MemberServiceImpl implements MemberService {
         memberRepository.save(member);
     }
 
+    //최소 8자 + 최소 한개의 대소문자 + 최소 한개의 숫자 + 최소 한개의 특수 문자
     public void verifyPasswordFormat(String password) throws InvalidPasswordFormatException {
-        String regex =  "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$";
+        String regex =  "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$";
         if (!password.matches(regex)) throw new InvalidPasswordFormatException();
     }
 

--- a/auth/src/main/resources/application.properties
+++ b/auth/src/main/resources/application.properties
@@ -1,1 +1,18 @@
 
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.datasource.url=jdbc:h2:~/test;
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.show_sql=true
+logging.level.org.hibernate.type.descriptor.sql=trace;
+spring.jpa.hibernate.ddl-auto=create
+
+server.port=8080
+

--- a/auth/src/test/java/frogslayer/auth/member/service/EmailValidationTest.java
+++ b/auth/src/test/java/frogslayer/auth/member/service/EmailValidationTest.java
@@ -72,4 +72,12 @@ class EmailValidationTest {
         String email = "username@dom.co.m";
         assertThrows(InvalidEmailFormatException.class, () -> memberService.verifyEmailFormat(email));
     }
+
+
+    @DisplayName("제대로 된 포맷임에도 예외가 발생하지 않는지 테스트")
+    @Test
+    void testWithValidEmailFormat(){
+        String email = "username@domain.com";
+        assertDoesNotThrow(() -> memberService.verifyEmailFormat(email));
+    }
 }

--- a/auth/src/test/java/frogslayer/auth/member/service/EmailValidationTest.java
+++ b/auth/src/test/java/frogslayer/auth/member/service/EmailValidationTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ContextConfiguration(classes = AuthApplication.class)
-class MemberServiceImplTest {
+class EmailValidationTest {
 
     @Autowired
     private MemberServiceImpl memberService;

--- a/auth/src/test/java/frogslayer/auth/member/service/MemberServiceImplTest.java
+++ b/auth/src/test/java/frogslayer/auth/member/service/MemberServiceImplTest.java
@@ -22,5 +22,11 @@ class MemberServiceImplTest {
         assertThrows(Exception.class, () -> memberService.verifyEmailFormat(email));
     }
 
+    @DisplayName("도메인 없는 이메일 가입 시도 테스트")
+    @Test
+    void testEmailValidationWithoutEmailDomain() {
+        String email = "email";
+        assertThrows(Exception.class, () -> memberService.verifyEmailFormat(email));
+    }
 
 }

--- a/auth/src/test/java/frogslayer/auth/member/service/MemberServiceImplTest.java
+++ b/auth/src/test/java/frogslayer/auth/member/service/MemberServiceImplTest.java
@@ -1,6 +1,8 @@
 package frogslayer.auth.member.service;
 
 import frogslayer.auth.AuthApplication;
+import frogslayer.auth.member.exception.exceptions.InvalidEmailFormatException;
+import frogslayer.auth.member.exception.exceptions.InvalidPasswordFormatException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,14 +21,55 @@ class MemberServiceImplTest {
     @Test
     void testEmailValidationWithBlank() {
         String email = "";
-        assertThrows(Exception.class, () -> memberService.verifyEmailFormat(email));
+        assertThrows(InvalidEmailFormatException.class, () -> memberService.verifyEmailFormat(email));
     }
 
     @DisplayName("도메인 없는 이메일 가입 시도 테스트")
     @Test
     void testEmailValidationWithoutEmailDomain() {
         String email = "email";
-        assertThrows(Exception.class, () -> memberService.verifyEmailFormat(email));
+        assertThrows(InvalidPasswordFormatException.class, () -> memberService.verifyEmailFormat(email));
     }
 
+    @DisplayName("최상위 도메인이 없는 이메일 가입 시도 테스트")
+    @Test
+    void testEmailValidationWithoutTLD() {
+        String email = "email@dom";
+        assertThrows(InvalidEmailFormatException.class, () -> memberService.verifyEmailFormat(email));
+    }
+
+    @DisplayName("최상위 도메인만 있는 이메일 가입 시도 테스트")
+    @Test
+    void testEmailValidationOnlyWithTLD() {
+        String email = "email@.com";
+        assertThrows(InvalidEmailFormatException.class, () -> memberService.verifyEmailFormat(email));
+    }
+
+    @DisplayName(". 뒤에 아무 것도 없는 경우 테스트")
+    @Test
+    void testEmailValidationNothingAfterDot() {
+        String email = "email@dom.";
+        assertThrows(InvalidEmailFormatException.class, () -> memberService.verifyEmailFormat(email));
+    }
+
+    @DisplayName("도메인만 있는 경우 테스트")
+    @Test
+    void testEmailValidationOnlyWithDomain() {
+        String email = "@dom.com";
+        assertThrows(InvalidEmailFormatException.class, () -> memberService.verifyEmailFormat(email));
+    }
+
+    @DisplayName("@가 두 개 이상 있는 경우 테스트")
+    @Test
+    void testEmailValidationWithMultipleAtS() {
+        String email = "user@name@dom.com";
+        assertThrows(InvalidEmailFormatException.class, () -> memberService.verifyEmailFormat(email));
+    }
+
+    @DisplayName(".이 두 개 이상 있는 경우 테스트")
+    @Test
+    void testEmailValidationWithMultipleDots() {
+        String email = "username@dom.co.m";
+        assertThrows(InvalidEmailFormatException.class, () -> memberService.verifyEmailFormat(email));
+    }
 }

--- a/auth/src/test/java/frogslayer/auth/member/service/MemberServiceImplTest.java
+++ b/auth/src/test/java/frogslayer/auth/member/service/MemberServiceImplTest.java
@@ -1,17 +1,26 @@
 package frogslayer.auth.member.service;
 
+import frogslayer.auth.AuthApplication;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SpringBootTest
+@ContextConfiguration(classes = AuthApplication.class)
 class MemberServiceImplTest {
 
+    @Autowired
+    private MemberServiceImpl memberService;
+    @DisplayName("빈 이메일로 가입 시도")
     @Test
-    void findUserByEmail() {
-
+    void testEmailValidationWithBlank() {
+        String email = "";
+        assertThrows(Exception.class, () -> memberService.verifyEmailFormat(email));
     }
 
-    @Test
-    void signUp() {
-    }
+
 }

--- a/auth/src/test/java/frogslayer/auth/member/service/PasswordValidationTest.java
+++ b/auth/src/test/java/frogslayer/auth/member/service/PasswordValidationTest.java
@@ -1,0 +1,65 @@
+package frogslayer.auth.member.service;
+
+import frogslayer.auth.AuthApplication;
+import frogslayer.auth.member.exception.exceptions.InvalidPasswordFormatException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+//최소 8자 + 최소 한개의 대소문자 + 최소 한개의 숫자 + 최소 한개의 특수 문자
+@SpringBootTest
+@ContextConfiguration(classes = AuthApplication.class)
+class PasswordValidationTest {
+
+    @Autowired
+    private MemberServiceImpl memberService;
+
+    @DisplayName("빈 비밀번호 테스트")
+    @Test
+    void testBlank() {
+        String password = "";
+        assertThrows(InvalidPasswordFormatException.class, () -> memberService.verifyPasswordFormat(password));
+    }
+
+    @DisplayName("8자 미만 테스트")
+    @Test
+    void testUnder8() {
+        String password = "paswo1!";
+        assertThrows(InvalidPasswordFormatException.class, () -> memberService.verifyPasswordFormat(password));
+    }
+
+
+    @DisplayName("대소문자 없는 경우 테스트")
+    @Test
+    void testWithoutAlphabet() {
+        String password = "123123!!";
+        assertThrows(InvalidPasswordFormatException.class, () -> memberService.verifyPasswordFormat(password));
+    }
+
+    @DisplayName("숫자 없는 경우 테스트")
+    @Test
+    void testWithoutNumber() {
+        String password = "password!";
+        assertThrows(InvalidPasswordFormatException.class, () -> memberService.verifyPasswordFormat(password));
+    }
+
+    @DisplayName("특수문자 없는 경우 테스트")
+    @Test
+    void testWithoutSpecialCharacter() {
+        String password = "password1";
+        assertThrows(InvalidPasswordFormatException.class, () -> memberService.verifyPasswordFormat(password));
+    }
+
+    @DisplayName("통과 사례")
+    @Test
+    void testValidPassword() {
+        String password = "password1!";
+        assertDoesNotThrow(() -> memberService.verifyPasswordFormat(password));
+    }
+
+}

--- a/auth/src/test/java/frogslayer/auth/member/service/SignUpTest.java
+++ b/auth/src/test/java/frogslayer/auth/member/service/SignUpTest.java
@@ -1,0 +1,68 @@
+package frogslayer.auth.member.service;
+
+import frogslayer.auth.AuthApplication;
+import frogslayer.auth.member.entity.Member;
+import frogslayer.auth.member.exception.exceptions.DuplicateUserException;
+import frogslayer.auth.member.exception.exceptions.InvalidEmailFormatException;
+import frogslayer.auth.member.exception.exceptions.InvalidPasswordFormatException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ContextConfiguration(classes = AuthApplication.class)
+class SignUpTest {
+
+    @Autowired
+    private MemberServiceImpl memberService;
+
+    @DisplayName("가입")
+    @Test
+    void signUpTest(){
+        String email = "username@domain.com";
+        String password = "password1!";
+
+        Member member = Member.builder()
+                        .email(email)
+                        .password(password)
+                        .build();
+
+        assertDoesNotThrow(() -> memberService.signUp(member));
+    }
+
+    @DisplayName("중복 가입 테스트")
+    @Test
+    void duplicateSignUpTest(){
+        signUpTest();
+        String email = "username@domain.com";
+        String password = "password1!";
+
+        Member member = Member.builder()
+                .email(email)
+                .password(password)
+                .build();
+
+        assertThrows(DuplicateUserException.class, () -> memberService.signUp(member));
+    }
+
+    @DisplayName("성공 사례 - 중복되지 않은 가입")
+    @Test
+    void testWithMultipleUser(){
+        signUpTest();
+        String email = "username2@domain.com";
+        String password = "password1!";
+
+        Member member = Member.builder()
+                .email(email)
+                .password(password)
+                .build();
+
+        assertDoesNotThrow(() -> memberService.signUp(member));
+    }
+}


### PR DESCRIPTION
## MemberServiceImpl에 대한 단위 테스트 메서드 구현 및 버그 픽스

### Test
+ validateEmailFormat(), validatePasswordFormat(), signUp(), checkEmailDuplication() 테스트 케이스 작성

### Fix
+ signUp()의 validatePasswordFormat()에 password 대신 email이 전달되던 것 수정
+ Member 엔티티의 Id 필드에 @GeneratedValue 애노테이션이 빠져 있던 것을 수정

### Add
+ application.properties에 h2 및 db 관련 설정 추가
